### PR TITLE
implement neverthrow in libjs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,10 @@
 import { config } from '@douglasneuroinformatics/eslint-config';
 
-export default config();
+export default config(
+  {},
+  {
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'error'
+    }
+  }
+);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "neverthrow": "^8.2.0",
     "type-fest": "^4.34.1",
     "zod": "^3.22.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      neverthrow:
+        specifier: ^8.2.0
+        version: 8.2.0
       type-fest:
         specifier: ^4.34.1
         version: 4.34.1
@@ -2798,6 +2801,11 @@ packages:
   nerf-dart@1.0.0:
     resolution:
       { integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g== }
+
+  neverthrow@8.2.0:
+    resolution:
+      { integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ== }
+    engines: { node: '>=18' }
 
   node-emoji@2.2.0:
     resolution:
@@ -6569,6 +6577,10 @@ snapshots:
   neo-async@2.6.2: {}
 
   nerf-dart@1.0.0: {}
+
+  neverthrow@8.2.0:
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.34.6
 
   node-emoji@2.2.0:
     dependencies:

--- a/src/__tests__/datetime.test.ts
+++ b/src/__tests__/datetime.test.ts
@@ -59,10 +59,12 @@ describe('sleep', () => {
 
 describe('parseDuration', () => {
   it('should fail to parse a negative duration', () => {
-    expect(() => parseDuration(-1)).toThrow('Cannot parse negative length of time: -1');
+    const result = parseDuration(-1);
+    expect(result.isErr());
   });
   it('should parse a duration of zero', () => {
-    expect(parseDuration(0)).toEqual({
+    const result = parseDuration(0);
+    expect(result.isOk() && result.value).toEqual({
       days: 0,
       hours: 0,
       milliseconds: 0,
@@ -71,14 +73,16 @@ describe('parseDuration', () => {
     });
   });
   it('should parse a duration less than a second', () => {
-    expect(parseDuration(50)).toEqual({
+    let result = parseDuration(50);
+    expect(result.isOk() && result.value).toEqual({
       days: 0,
       hours: 0,
       milliseconds: 50,
       minutes: 0,
       seconds: 0
     });
-    expect(parseDuration(500)).toEqual({
+    result = parseDuration(500);
+    expect(result.isOk() && result.value).toEqual({
       days: 0,
       hours: 0,
       milliseconds: 500,
@@ -87,7 +91,8 @@ describe('parseDuration', () => {
     });
   });
   it('should parse a duration less than one minute but more than one second', () => {
-    expect(parseDuration(11_100)).toEqual({
+    const result = parseDuration(11_100);
+    expect(result.isOk() && result.value).toEqual({
       days: 0,
       hours: 0,
       milliseconds: 100,
@@ -96,14 +101,16 @@ describe('parseDuration', () => {
     });
   });
   it('should parse a duration less than one hour but more than one minute', () => {
-    expect(parseDuration(60_000)).toEqual({
+    let result = parseDuration(60_000);
+    expect(result.isOk() && result.value).toEqual({
       days: 0,
       hours: 0,
       milliseconds: 0,
       minutes: 1,
       seconds: 0
     });
-    expect(parseDuration(62_500)).toEqual({
+    result = parseDuration(62_500);
+    expect(result.isOk() && result.value).toEqual({
       days: 0,
       hours: 0,
       milliseconds: 500,
@@ -111,9 +118,9 @@ describe('parseDuration', () => {
       seconds: 2
     });
   });
-
   it('should parse a duration less than one day but more than one hour', () => {
-    expect(parseDuration(3_600_000)).toEqual({
+    const result = parseDuration(3_600_000);
+    expect(result.isOk() && result.value).toEqual({
       days: 0,
       hours: 1,
       milliseconds: 0,
@@ -122,14 +129,16 @@ describe('parseDuration', () => {
     });
   });
   it('should parse a duration greater than one day', () => {
-    expect(parseDuration(86_400_000)).toEqual({
+    let result = parseDuration(86_400_000);
+    expect(result.isOk() && result.value).toEqual({
       days: 1,
       hours: 0,
       milliseconds: 0,
       minutes: 0,
       seconds: 0
     });
-    expect(parseDuration(4_351_505_030)).toEqual({
+    result = parseDuration(4_351_505_030);
+    expect(result.isOk() && result.value).toEqual({
       days: 50,
       hours: 8,
       milliseconds: 30,

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, expectTypeOf, it, test } from 'vitest';
 
 import { BaseException, ExceptionBuilder, OutOfRangeException, ValueException } from '../exception.js';
 
-import type { ExceptionConstructor, ExceptionInstance } from '../exception.js';
+import type { ExceptionConstructor } from '../exception.js';
 
 type ExceptionOptionsWithCode = Simplify<ErrorOptions & { details: { code: number } }>;
 type ExceptionOptionsWithCause = Simplify<ErrorOptions & { cause: Error }>;
@@ -14,30 +14,27 @@ type ExceptionParamsWithMessage = Simplify<ExceptionParams & { message: string }
 
 test('ExceptionConstructor', () => {
   expectTypeOf<ExceptionConstructor<ExceptionParams, ErrorOptions>>().toEqualTypeOf<
-    new (message?: string, options?: ErrorOptions) => ExceptionInstance<ExceptionParams, ErrorOptions>
+    new (message?: string, options?: ErrorOptions) => BaseException<ExceptionParams, ErrorOptions>
   >();
   expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCode>>().toEqualTypeOf<
-    new (
-      message: string,
-      options: ExceptionOptionsWithCode
-    ) => ExceptionInstance<ExceptionParams, ExceptionOptionsWithCode>
+    new (message: string, options: ExceptionOptionsWithCode) => BaseException<ExceptionParams, ExceptionOptionsWithCode>
   >();
   expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCause>>().toEqualTypeOf<
     new (
       message: string,
       options: ExceptionOptionsWithCause
-    ) => ExceptionInstance<ExceptionParams, ExceptionOptionsWithCause>
+    ) => BaseException<ExceptionParams, ExceptionOptionsWithCause>
   >();
   expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCodeAndCause>>().toEqualTypeOf<
     new (
       message: string,
       options: ExceptionOptionsWithCodeAndCause
-    ) => ExceptionInstance<ExceptionParams, ExceptionOptionsWithCodeAndCause>
+    ) => BaseException<ExceptionParams, ExceptionOptionsWithCodeAndCause>
   >();
   expectTypeOf<ExceptionConstructor<ExceptionParamsWithMessage, ExceptionOptionsWithCodeAndCause>>().toEqualTypeOf<
     new (
       options: ExceptionOptionsWithCodeAndCause
-    ) => ExceptionInstance<ExceptionParamsWithMessage, ExceptionOptionsWithCodeAndCause>
+    ) => BaseException<ExceptionParamsWithMessage, ExceptionOptionsWithCodeAndCause>
   >();
 });
 

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -55,7 +55,7 @@ describe('BaseException', () => {
 
 describe('ExceptionBuilder', () => {
   it('should return never for the build method if no name is specified', () => {
-    const fn = () => new ExceptionBuilder().build();
+    const fn = (): never => new ExceptionBuilder().build();
     expect(fn).toThrow('Cannot build exception: params is undefined');
     expectTypeOf<ReturnType<typeof fn>>().toBeNever();
   });

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -136,6 +136,6 @@ describe('OutOfRangeError', () => {
         value: -1
       }
     });
-    expect(error.message).toBeTypeOf('string');
+    expect(error.message).toBe('Value -1 is out of range (0 - Infinity)');
   });
 });

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -1,7 +1,7 @@
 import type { Simplify } from 'type-fest';
 import { describe, expect, expectTypeOf, it, test } from 'vitest';
 
-import { BaseException, ExceptionBuilder, ValueError } from '../exception.js';
+import { BaseException, ExceptionBuilder, OutOfRangeError, ValueError } from '../exception.js';
 
 import type { ExceptionConstructor, ExceptionInstance } from '../exception.js';
 
@@ -121,5 +121,11 @@ describe('ExceptionBuilder', () => {
 describe('ValueError', () => {
   it('should have the correct prototype', () => {
     expect(Object.getPrototypeOf(ValueError)).toBe(BaseException);
+  });
+});
+
+describe('OutOfRangeError', () => {
+  it('should have the correct prototype', () => {
+    expect(Object.getPrototypeOf(OutOfRangeError)).toBe(ValueError);
   });
 });

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -13,25 +13,25 @@ type ExceptionParams = { name: 'TestException' };
 type ExceptionParamsWithMessage = Simplify<ExceptionParams & { message: string }>;
 
 test('ExceptionConstructor', () => {
-  expectTypeOf<ExceptionConstructor<ExceptionParams, ErrorOptions>>().toEqualTypeOf<
+  expectTypeOf<ExceptionConstructor<ExceptionParams, ErrorOptions>>().toMatchTypeOf<
     new (message?: string, options?: ErrorOptions) => BaseException<ExceptionParams, ErrorOptions>
   >();
-  expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCode>>().toEqualTypeOf<
+  expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCode>>().toMatchTypeOf<
     new (message: string, options: ExceptionOptionsWithCode) => BaseException<ExceptionParams, ExceptionOptionsWithCode>
   >();
-  expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCause>>().toEqualTypeOf<
+  expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCause>>().toMatchTypeOf<
     new (
       message: string,
       options: ExceptionOptionsWithCause
     ) => BaseException<ExceptionParams, ExceptionOptionsWithCause>
   >();
-  expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCodeAndCause>>().toEqualTypeOf<
+  expectTypeOf<ExceptionConstructor<ExceptionParams, ExceptionOptionsWithCodeAndCause>>().toMatchTypeOf<
     new (
       message: string,
       options: ExceptionOptionsWithCodeAndCause
     ) => BaseException<ExceptionParams, ExceptionOptionsWithCodeAndCause>
   >();
-  expectTypeOf<ExceptionConstructor<ExceptionParamsWithMessage, ExceptionOptionsWithCodeAndCause>>().toEqualTypeOf<
+  expectTypeOf<ExceptionConstructor<ExceptionParamsWithMessage, ExceptionOptionsWithCodeAndCause>>().toMatchTypeOf<
     new (
       options: ExceptionOptionsWithCodeAndCause
     ) => BaseException<ExceptionParamsWithMessage, ExceptionOptionsWithCodeAndCause>

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -1,7 +1,7 @@
 import type { Simplify } from 'type-fest';
 import { describe, expect, expectTypeOf, it, test } from 'vitest';
 
-import { BaseException, ExceptionBuilder } from '../exception.js';
+import { BaseException, ExceptionBuilder, ValueError } from '../exception.js';
 
 import type { ExceptionConstructor, ExceptionInstance } from '../exception.js';
 
@@ -115,5 +115,11 @@ describe('ExceptionBuilder', () => {
     const error = new TestException({ cause: new Error('Test') });
     expect(error.message).toBe('Custom message');
     expectTypeOf<ConstructorParameters<typeof TestException>>().toEqualTypeOf<[options: { cause: Error }]>();
+  });
+});
+
+describe('ValueError', () => {
+  it('should have the correct prototype', () => {
+    expect(Object.getPrototypeOf(ValueError)).toBe(BaseException);
   });
 });

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -128,14 +128,22 @@ describe('OutOfRangeError', () => {
   it('should have the correct prototype', () => {
     expect(Object.getPrototypeOf(OutOfRangeError)).toBe(ValueError);
   });
-  it('should create the correct message', () => {
-    const error = new OutOfRangeError({
-      details: {
-        max: Infinity,
-        min: 0,
-        value: -1
-      }
+  describe('constructor', () => {
+    it('should create the correct message', () => {
+      const error = new OutOfRangeError({
+        details: {
+          max: Infinity,
+          min: 0,
+          value: -1
+        }
+      });
+      expect(error.message).toBe('Value -1 is out of range (0 - Infinity)');
     });
-    expect(error.message).toBe('Value -1 is out of range (0 - Infinity)');
+  });
+  describe('ForNonPositive', () => {
+    it('should create the correct message', () => {
+      const error = OutOfRangeError.forNonPositive(-1);
+      expect(error.message).toBe('Value -1 is out of range (0 - Infinity)');
+    });
   });
 });

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -1,7 +1,7 @@
 import type { Simplify } from 'type-fest';
 import { describe, expect, expectTypeOf, it, test } from 'vitest';
 
-import { BaseException, ExceptionBuilder, OutOfRangeError, ValueError } from '../exception.js';
+import { BaseException, ExceptionBuilder, OutOfRangeException, ValueException } from '../exception.js';
 
 import type { ExceptionConstructor, ExceptionInstance } from '../exception.js';
 
@@ -63,7 +63,7 @@ describe('ExceptionBuilder', () => {
     expectTypeOf<ReturnType<typeof fn>>().toBeNever();
   });
   it('should build an exception with the provided name and message', () => {
-    const TestException = new ExceptionBuilder().setParams({ name: 'TestException' }).build();
+    const { TestException } = new ExceptionBuilder().setParams({ name: 'TestException' }).build();
     expect(Object.getPrototypeOf(TestException)).toBe(BaseException);
     expectTypeOf<Pick<InstanceType<typeof TestException>, 'name'>>().toEqualTypeOf<{ name: 'TestException' }>();
     const error = new TestException('This is a test');
@@ -73,8 +73,8 @@ describe('ExceptionBuilder', () => {
   });
 
   it('should create distinct constructors', () => {
-    const TestException = new ExceptionBuilder().setParams({ name: 'TestException' }).build();
-    const OtherException = new ExceptionBuilder().setParams({ name: 'OtherException' }).build();
+    const { TestException } = new ExceptionBuilder().setParams({ name: 'TestException' }).build();
+    const { OtherException } = new ExceptionBuilder().setParams({ name: 'OtherException' }).build();
     const e1 = new TestException('This is a test');
     const e2 = new OtherException('This is a test');
     expect(e1).toBeInstanceOf(BaseException);
@@ -84,7 +84,7 @@ describe('ExceptionBuilder', () => {
   });
 
   it('should allow creating an exception with additional details', () => {
-    const TestException = new ExceptionBuilder()
+    const { TestException } = new ExceptionBuilder()
       .setParams({ name: 'TestException' })
       .setOptionsType<{ details: { code: number } }>()
       .build();
@@ -96,7 +96,7 @@ describe('ExceptionBuilder', () => {
   });
 
   it('should allow creating an error with a custom cause', () => {
-    const TestException = new ExceptionBuilder()
+    const { TestException } = new ExceptionBuilder()
       .setParams({ name: 'TestException' })
       .setOptionsType<{ cause: Error }>()
       .build();
@@ -108,7 +108,7 @@ describe('ExceptionBuilder', () => {
   });
 
   it('should allow creating an error with a default message', () => {
-    const TestException = new ExceptionBuilder()
+    const { TestException } = new ExceptionBuilder()
       .setParams({ message: 'Custom message', name: 'TestException' })
       .setOptionsType<{ cause: Error }>()
       .build();
@@ -118,19 +118,19 @@ describe('ExceptionBuilder', () => {
   });
 });
 
-describe('ValueError', () => {
+describe('ValueException', () => {
   it('should have the correct prototype', () => {
-    expect(Object.getPrototypeOf(ValueError)).toBe(BaseException);
+    expect(Object.getPrototypeOf(ValueException)).toBe(BaseException);
   });
 });
 
-describe('OutOfRangeError', () => {
+describe('OutOfRangeException', () => {
   it('should have the correct prototype', () => {
-    expect(Object.getPrototypeOf(OutOfRangeError)).toBe(ValueError);
+    expect(Object.getPrototypeOf(OutOfRangeException)).toBe(ValueException);
   });
   describe('constructor', () => {
     it('should create the correct message', () => {
-      const error = new OutOfRangeError({
+      const error = new OutOfRangeException({
         details: {
           max: Infinity,
           min: 0,
@@ -142,7 +142,7 @@ describe('OutOfRangeError', () => {
   });
   describe('ForNonPositive', () => {
     it('should create the correct message', () => {
-      const error = OutOfRangeError.forNonPositive(-1);
+      const error = OutOfRangeException.forNonPositive(-1);
       expect(error.message).toBe('Value -1 is out of range (0 - Infinity)');
     });
   });

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -128,4 +128,14 @@ describe('OutOfRangeError', () => {
   it('should have the correct prototype', () => {
     expect(Object.getPrototypeOf(OutOfRangeError)).toBe(ValueError);
   });
+  it('should create the correct message', () => {
+    const error = new OutOfRangeError({
+      details: {
+        max: Infinity,
+        min: 0,
+        value: -1
+      }
+    });
+    expect(error.message).toBeTypeOf('string');
+  });
 });

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { deepFreeze, filterObject, isAllUndefined, isObject, isObjectLike, isPlainObject } from '../object.js';
+import {
+  deepFreeze,
+  filterObject,
+  isAllUndefined,
+  isObject,
+  isObjectLike,
+  isPlainObject,
+  objectify
+} from '../object.js';
 
 describe('deepFreeze', () => {
   it('should not allow mutating a primitive value', () => {
@@ -94,5 +102,11 @@ describe('filterValues', () => {
     expect(filterObject({ a: 1, b: 'hello' }, (value) => typeof value === 'number')).toStrictEqual({
       a: 1
     });
+  });
+});
+
+describe('objectify', () => {
+  it('should create a single key map', () => {
+    expect(objectify('foo', 'bar')).toStrictEqual({ foo: 'bar' });
   });
 });

--- a/src/__tests__/random.test.ts
+++ b/src/__tests__/random.test.ts
@@ -6,25 +6,25 @@ describe('randomInt', () => {
   it('should return an integer value within the range', () => {
     const min = 5;
     const max = 8;
-    const result = randomInt(min, max);
+    const result = randomInt(min, max)._unsafeUnwrap();
     expect(result).toBeGreaterThanOrEqual(min);
     expect(result).toBeLessThan(8);
     expect(Number.isInteger(result)).toBe(true);
   });
-  it('should throw if the min value is larger than the max', () => {
-    expect(() => randomInt(10, 5)).toThrow();
+  it('should return an error if the min value is larger than the max', () => {
+    expect(randomInt(10, 5).isErr()).toBe(true);
   });
-  it('should throw if the min value equals the max', () => {
-    expect(() => randomInt(10, 10)).toThrow();
+  it('should return an error if the min value equals the max', () => {
+    expect(randomInt(10, 10).isErr()).toBe(true);
   });
   it('should handle negative values', () => {
     const min = -5;
     const max = -3;
-    const result = randomInt(min, max);
+    const result = randomInt(min, max)._unsafeUnwrap();
     expect(result).toBeGreaterThanOrEqual(min);
     expect(result).toBeLessThan(8);
     expect(Number.isInteger(result)).toBe(true);
-    expect(() => randomInt(max, min)).toThrow();
+    expect(randomInt(max, min).isErr()).toBe(true);
   });
 });
 
@@ -32,22 +32,22 @@ describe('randomDate', () => {
   it('should return a date within the range', () => {
     const start = new Date(2000, 0, 1);
     const end = new Date();
-    const random = randomDate(start, end);
+    const random = randomDate(start, end)._unsafeUnwrap();
     expect(random.getTime() >= start.getTime()).toBe(true);
     expect(random.getTime() <= end.getTime()).toBe(true);
   });
-  it('should throw if the end is before the start', () => {
-    expect(() => randomDate(new Date(), new Date(2000, 0, 1))).toThrow();
+  it('should return an error if the end is before the start', () => {
+    expect(randomDate(new Date(), new Date(2000, 0, 1)).isErr()).toBe(true);
   });
 });
 
 describe('randomValue', () => {
-  it('should throw if given an empty array', () => {
-    expect(() => randomValue([])).toThrow();
+  it('should return an error if given an empty array', () => {
+    expect(randomValue([]).isErr()).toBe(true);
   });
   it('should return a value in the array', () => {
     const arr = [-10, -20, -30];
-    expect(arr.includes(randomValue(arr)));
+    expect(arr.includes(randomValue(arr)._unsafeUnwrap()));
   });
   it('should not mutate the array', () => {
     const arr = [-10, -20, -30];

--- a/src/__tests__/random.test.ts
+++ b/src/__tests__/random.test.ts
@@ -47,7 +47,7 @@ describe('randomValue', () => {
   });
   it('should return a value in the array', () => {
     const arr = [-10, -20, -30];
-    expect(arr.includes(randomValue(arr)!));
+    expect(arr.includes(randomValue(arr)));
   });
   it('should not mutate the array', () => {
     const arr = [-10, -20, -30];

--- a/src/__tests__/range.test.ts
+++ b/src/__tests__/range.test.ts
@@ -4,10 +4,10 @@ import { range } from '../range.js';
 
 describe('range', () => {
   it('should return an array equal in length to the range', () => {
-    const arr = range(10);
+    const arr = range(10)._unsafeUnwrap();
     expect(arr.length).toBe(10);
   });
-  it('should throw an error if the start is equal to the end', () => {
-    expect(() => range(1, 1)).toThrow();
+  it('should return an error if the start is equal to the end', () => {
+    expect(range(1, 1).isErr()).toBe(true);
   });
 });

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,0 +1,7 @@
+import { describe, expectTypeOf } from 'vitest';
+
+import type { ToAbstractConstructor } from '../types.js';
+
+describe('ToAbstractConstructor', () => {
+  expectTypeOf<ToAbstractConstructor<new () => { foo: string }>>().toEqualTypeOf<abstract new () => { foo: string }>();
+});

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,7 +1,7 @@
-import { describe, expectTypeOf } from 'vitest';
+import { expectTypeOf, test } from 'vitest';
 
 import type { ToAbstractConstructor } from '../types.js';
 
-describe('ToAbstractConstructor', () => {
+test('ToAbstractConstructor', () => {
   expectTypeOf<ToAbstractConstructor<new () => { foo: string }>>().toEqualTypeOf<abstract new () => { foo: string }>();
 });

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,7 +1,22 @@
 import { expectTypeOf, test } from 'vitest';
 
-import type { ToAbstractConstructor } from '../types.js';
+import type { IsUnion, SingleKeyMap, ToAbstractConstructor } from '../types.js';
 
 test('ToAbstractConstructor', () => {
   expectTypeOf<ToAbstractConstructor<new () => { foo: string }>>().toEqualTypeOf<abstract new () => { foo: string }>();
+});
+
+test('IsUnion', () => {
+  expectTypeOf<IsUnion<string>>().toEqualTypeOf<false>();
+  expectTypeOf<IsUnion<number | string>>().toEqualTypeOf<true>();
+  expectTypeOf<IsUnion<1 | 2>>().toEqualTypeOf<true>();
+  expectTypeOf<IsUnion<1>>().toEqualTypeOf<false>();
+  expectTypeOf<IsUnion<'bar' | 'foo'>>().toEqualTypeOf<true>();
+  expectTypeOf<IsUnion<'foo'>>().toEqualTypeOf<false>();
+});
+
+test('SingleKeyMap', () => {
+  expectTypeOf<SingleKeyMap<string, number>>().toBeNever();
+  expectTypeOf<SingleKeyMap<'bar' | 'foo', number>>().toBeNever();
+  expectTypeOf<SingleKeyMap<'foo', number>>().toEqualTypeOf<{ foo: number }>();
 });

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,13 +1,13 @@
 /**
  * Return whether all items in the array are unique
  */
-export function isUnique(arr: unknown[]) {
+export function isUnique(arr: unknown[]): boolean {
   return new Set(arr).size === arr.length;
 }
 
 /**
  * Return whether the array contains duplicate values
  */
-export function hasDuplicates(arr: unknown[]) {
+export function hasDuplicates(arr: unknown[]): boolean {
   return !isUnique(arr);
 }

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -76,7 +76,7 @@ export async function sleep(seconds: number): Promise<void> {
  * @returns An result of type `Duration` representing the parsed duration. This will return an OutOfRangeException
  * if the input is negative.
  */
-export function parseDuration(milliseconds: number): Result<Duration, typeof OutOfRangeException.infer> {
+export function parseDuration(milliseconds: number): Result<Duration, typeof OutOfRangeException.Instance> {
   if (0 > milliseconds) {
     return err(OutOfRangeException.forNonPositive(milliseconds));
   }

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -29,7 +29,7 @@ export const TIME_MAP = new Map([
  * @param date - The Date object to be converted.
  * @returns An ISO 8601 formatted string representing the local time.
  */
-export function toLocalISOString(date: Date) {
+export function toLocalISOString(date: Date): string {
   return new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString().slice(0, -1);
 }
 
@@ -65,7 +65,7 @@ export function yearsPassed(date: Date): number {
  * await sleep(5);
  * ```
  */
-export async function sleep(seconds: number) {
+export async function sleep(seconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 }
 

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -1,3 +1,8 @@
+import { err, ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
+
+import { OutOfRangeException } from './exception.js';
+
 export type Duration = {
   days: number;
   hours: number;
@@ -68,12 +73,12 @@ export async function sleep(seconds: number) {
  * Parses a given duration in milliseconds into an object representing the duration in days, hours, minutes, seconds, and milliseconds.
  *
  * @param milliseconds - The duration in milliseconds to be parsed.
- * @returns An object of type `Duration` representing the parsed duration.
+ * @returns An result of type `Duration` representing the parsed duration.
  * @throws Will throw an error if the input duration is negative.
  */
-export function parseDuration(milliseconds: number): Duration {
+export function parseDuration(milliseconds: number): Result<Duration, typeof OutOfRangeException.infer> {
   if (0 > milliseconds) {
-    throw new Error(`Cannot parse negative length of time: ${milliseconds}`);
+    return err(OutOfRangeException.forNonPositive(milliseconds));
   }
   const duration: Partial<Duration> = {};
   let remaining = milliseconds;
@@ -82,5 +87,5 @@ export function parseDuration(milliseconds: number): Duration {
     duration[`${unit}s`] = count;
     remaining %= value;
   });
-  return duration as Duration;
+  return ok(duration as Duration);
 }

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -73,8 +73,8 @@ export async function sleep(seconds: number) {
  * Parses a given duration in milliseconds into an object representing the duration in days, hours, minutes, seconds, and milliseconds.
  *
  * @param milliseconds - The duration in milliseconds to be parsed.
- * @returns An result of type `Duration` representing the parsed duration.
- * @throws Will throw an error if the input duration is negative.
+ * @returns An result of type `Duration` representing the parsed duration. This will return an OutOfRangeException
+ * if the input is negative.
  */
 export function parseDuration(milliseconds: number): Result<Duration, typeof OutOfRangeException.infer> {
   if (0 > milliseconds) {

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -73,13 +73,6 @@ class ExceptionBuilder<
   private params?: TParams;
   private staticMethods = {} as TStaticMethods;
 
-  static createCoreException<TName extends ExceptionName>(name: TName): SingleKeyMap<TName, CoreExceptionConstructor> {
-    const constructor = class extends BaseException<{ name: TName }, ExceptionOptions> {
-      override name = name;
-    };
-    return objectify(name, constructor);
-  }
-
   build(): [TParams] extends [ExceptionParams]
     ? SingleKeyMap<TParams['name'], ExceptionType<NonNullable<TParams>, TOptions, TStaticMethods>>
     : never;
@@ -140,7 +133,7 @@ class ExceptionBuilder<
   }
 }
 
-const { ValueException } = ExceptionBuilder.createCoreException('ValueException');
+const { ValueException } = new ExceptionBuilder().setParams({ name: 'ValueException' }).build();
 
 const { OutOfRangeException } = new ExceptionBuilder()
   .extend(ValueException)

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -1,6 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable no-dupe-class-members */
 
-import { err } from 'neverthrow';
+import { Err, err } from 'neverthrow';
 import type { IsNever, RequiredKeysOf, Simplify } from 'type-fest';
 
 import type { ToAbstractConstructor } from './types.js';
@@ -44,7 +45,7 @@ abstract class BaseException<TParams extends ExceptionParams, TOptions extends E
     this.details = options?.details;
   }
 
-  toErr() {
+  toErr(): Err<never, this> {
     return err(this);
   }
 }
@@ -85,7 +86,7 @@ class ExceptionBuilder<
     constructor: ToAbstractConstructor<ExceptionConstructor<TConstructorParams, TConstructorOptions>>,
     name: TConstructorParams['name'],
     props?: TStaticProps
-  ) {
+  ): ExceptionBuildReturnType<TConstructorParams, TConstructorOptions, TStaticProps> {
     return { [name]: Object.assign(constructor, props) } as ExceptionBuildReturnType<
       TConstructorParams,
       TConstructorOptions,
@@ -118,26 +119,32 @@ class ExceptionBuilder<
     return ExceptionBuilder.createResult(constructor, params.name, this.staticMethods);
   }
 
-  extend(constructor: CoreExceptionConstructor) {
+  extend(constructor: CoreExceptionConstructor): this {
     this.base = constructor;
     return this;
   }
 
-  setOptionsType<TUpdatedOptions extends ExceptionOptions>() {
-    return this as unknown as ExceptionBuilder<TParams, TUpdatedOptions, TStaticMethods>;
+  setOptionsType<TUpdatedOptions extends ExceptionOptions>(): ExceptionBuilder<
+    TParams,
+    TUpdatedOptions,
+    TStaticMethods
+  > {
+    return this as any;
   }
 
-  setParams<const TUpdatedParams extends ExceptionParams<TOptions['details']>>(params: TUpdatedParams) {
+  setParams<const TUpdatedParams extends ExceptionParams<TOptions['details']>>(
+    params: TUpdatedParams
+  ): ExceptionBuilder<TUpdatedParams, TOptions, TStaticMethods> {
     this.params = params as unknown as TParams;
-    return this as unknown as ExceptionBuilder<TUpdatedParams, TOptions, TStaticMethods>;
+    return this as any;
   }
 
   setStaticMethod<
     TName extends string,
     TMethod extends (this: ExceptionConstructor<NonNullable<TParams>, TOptions>, ...args: any[]) => any
-  >(name: TName, method: TMethod) {
+  >(name: TName, method: TMethod): ExceptionBuilder<TParams, TOptions, TStaticMethods & { [K in TName]: TMethod }> {
     this.staticMethods = { ...this.staticMethods, [name]: method };
-    return this as unknown as ExceptionBuilder<TParams, TOptions, TStaticMethods & { [K in TName]: TMethod }>;
+    return this as any;
   }
 }
 

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -45,19 +45,16 @@ abstract class BaseException<TParams extends ExceptionParams, TOptions extends E
     this.cause = options?.cause;
     this.details = options?.details;
   }
-
-  // static extend() {
-  //   return class extends this {};
-  // }
 }
-
-abstract class ValueError<TParams extends ExceptionParams, TOptions extends ExceptionOptions> extends BaseException<
-  TParams,
-  TOptions
-> {}
 
 class ExceptionBuilder<TParams extends ExceptionParams | undefined, TOptions extends ExceptionOptions> {
   private params?: TParams;
+
+  static createCoreException<TName extends string>(name: TName) {
+    return class extends BaseException<{ name: TName }, ExceptionOptions> {
+      override name = name;
+    };
+  }
 
   build(): [TParams] extends [ExceptionParams] ? ExceptionConstructor<TParams, TOptions> : never;
   build(): ExceptionConstructor<NonNullable<TParams>, TOptions> | never {
@@ -83,6 +80,8 @@ class ExceptionBuilder<TParams extends ExceptionParams | undefined, TOptions ext
     return this as unknown as ExceptionBuilder<TUpdatedParams, TOptions>;
   }
 }
+
+const ValueError = ExceptionBuilder.createCoreException('ValueError');
 
 export type { ExceptionConstructor, ExceptionInstance };
 export { BaseException, ExceptionBuilder, ValueError };

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -36,13 +36,15 @@ type ExceptionStatic<TParams extends ExceptionParams, TOptions extends Exception
   Instance: BaseException<TParams, TOptions>;
 };
 
-type ExceptionConstructor<
+type ExceptionConstructor<TParams extends ExceptionParams, TOptions extends ExceptionOptions> = new (
+  ...args: ExceptionConstructorArgs<TParams, TOptions>
+) => BaseException<TParams, TOptions>;
+
+type ExceptionType<
   TParams extends ExceptionParams,
   TOptions extends ExceptionOptions,
   TStaticProps = unknown
-> = ExceptionStatic<TParams, TOptions> &
-  TStaticProps &
-  (new (...args: ExceptionConstructorArgs<TParams, TOptions>) => BaseException<TParams, TOptions>);
+> = ExceptionConstructor<TParams, TOptions> & ExceptionStatic<TParams, TOptions> & TStaticProps;
 
 abstract class BaseException<TParams extends ExceptionParams, TOptions extends ExceptionOptions> extends Error {
   override cause: TOptions['cause'];
@@ -79,12 +81,9 @@ class ExceptionBuilder<
   }
 
   build(): [TParams] extends [ExceptionParams]
-    ? SingleKeyMap<TParams['name'], ExceptionConstructor<NonNullable<TParams>, TOptions, TStaticMethods>>
+    ? SingleKeyMap<TParams['name'], ExceptionType<NonNullable<TParams>, TOptions, TStaticMethods>>
     : never;
-  build(): SingleKeyMap<
-    NonNullable<TParams>['name'],
-    ExceptionConstructor<NonNullable<TParams>, TOptions, TStaticMethods>
-  > {
+  build(): SingleKeyMap<NonNullable<TParams>['name'], ExceptionType<NonNullable<TParams>, TOptions, TStaticMethods>> {
     if (!this.params) {
       throw new Error('Cannot build exception: params is undefined');
     }

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-dupe-class-members */
 
+import { err } from 'neverthrow';
 import type { IsNever, RequiredKeysOf, Simplify } from 'type-fest';
 
 import type { ToAbstractConstructor } from './types.js';
@@ -39,6 +40,10 @@ abstract class BaseException<TParams extends ExceptionParams, TOptions extends E
     super(message);
     this.cause = options?.cause;
     this.details = options?.details;
+  }
+
+  toErr() {
+    return err(this);
   }
 }
 

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -2,19 +2,18 @@
 /* eslint-disable no-dupe-class-members */
 
 import { Err, err } from 'neverthrow';
-import type { IsNever, RequiredKeysOf, Simplify } from 'type-fest';
+import type { IsNever, RequiredKeysOf } from 'type-fest';
 
 import type { ToAbstractConstructor } from './types.js';
 
 type ExceptionName = `${string}Exception`;
 
-type ExceptionOptions = Simplify<
-  ErrorOptions & {
-    details?: {
-      [key: string]: unknown;
-    };
-  }
->;
+type ExceptionOptions = {
+  cause?: unknown;
+  details?: {
+    [key: string]: unknown;
+  };
+};
 
 type ExceptionParams<TDetails = any> = {
   message?: ((details: TDetails) => string) | string;
@@ -36,9 +35,9 @@ type ExceptionConstructor<TParams extends ExceptionParams, TOptions extends Exce
 };
 
 abstract class BaseException<TParams extends ExceptionParams, TOptions extends ExceptionOptions> extends Error {
-  public override cause: TOptions['cause'];
-  public details: TOptions['details'];
-  public abstract override name: TParams['name'];
+  override cause: TOptions['cause'];
+  details: TOptions['details'];
+  abstract override name: TParams['name'];
 
   constructor(message?: string, options?: TOptions) {
     super(message);

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -75,5 +75,7 @@ class ExceptionBuilder<TParams extends ExceptionParams | undefined, TOptions ext
   }
 }
 
+const ValueError = new ExceptionBuilder().setParams({ name: 'ValueError' }).build();
+
 export type { ExceptionConstructor, ExceptionInstance };
-export { BaseException, ExceptionBuilder };
+export { BaseException, ExceptionBuilder, ValueError };

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -19,12 +19,6 @@ type ExceptionParams<TDetails = any> = {
   name: ExceptionName;
 };
 
-type ExceptionInstance<TParams extends ExceptionParams, TOptions extends ExceptionOptions> = Error & {
-  cause: TOptions['cause'];
-  details: TOptions['details'];
-  name: TParams['name'];
-};
-
 type ExceptionConstructorArgs<TParams extends ExceptionParams, TOptions extends ExceptionOptions> =
   IsNever<RequiredKeysOf<TOptions>> extends true
     ? [message?: string, options?: TOptions]
@@ -34,12 +28,9 @@ type ExceptionConstructorArgs<TParams extends ExceptionParams, TOptions extends 
 
 type ExceptionConstructor<TParams extends ExceptionParams, TOptions extends ExceptionOptions> = new (
   ...args: ExceptionConstructorArgs<TParams, TOptions>
-) => ExceptionInstance<TParams, TOptions>;
+) => BaseException<TParams, TOptions>;
 
-abstract class BaseException<TParams extends ExceptionParams, TOptions extends ExceptionOptions>
-  extends Error
-  implements ExceptionInstance<TParams, TOptions>
-{
+abstract class BaseException<TParams extends ExceptionParams, TOptions extends ExceptionOptions> extends Error {
   public override cause: TOptions['cause'];
   public details: TOptions['details'];
   public abstract override name: TParams['name'];
@@ -156,5 +147,5 @@ const { OutOfRangeException } = new ExceptionBuilder()
   })
   .build();
 
-export type { ExceptionConstructor, ExceptionInstance };
+export type { ExceptionConstructor };
 export { BaseException, ExceptionBuilder, OutOfRangeException, ValueException };

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -27,9 +27,11 @@ type ExceptionConstructorArgs<TParams extends ExceptionParams, TOptions extends 
       ? [TOptions]
       : [message: string, options: TOptions];
 
-type ExceptionConstructor<TParams extends ExceptionParams, TOptions extends ExceptionOptions> = new (
-  ...args: ExceptionConstructorArgs<TParams, TOptions>
-) => BaseException<TParams, TOptions>;
+type ExceptionConstructor<TParams extends ExceptionParams, TOptions extends ExceptionOptions> = {
+  new (...args: ExceptionConstructorArgs<TParams, TOptions>): BaseException<TParams, TOptions>;
+  /** inference-only property that will be undefined at runtime */
+  infer: BaseException<TParams, TOptions>;
+};
 
 abstract class BaseException<TParams extends ExceptionParams, TOptions extends ExceptionOptions> extends Error {
   public override cause: TOptions['cause'];
@@ -99,6 +101,7 @@ class ExceptionBuilder<
     }
     const params = this.params;
     const constructor: ExceptionConstructor<NonNullable<TParams>, TOptions> = class extends this.base {
+      static infer: BaseException<NonNullable<TParams>, TOptions>;
       override name = params.name;
       constructor(...args: ExceptionConstructorArgs<NonNullable<TParams>, TOptions>) {
         let message: string | undefined, options: TOptions | undefined;

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -63,9 +63,9 @@ class ExceptionBuilder<
   TOptions extends ExceptionOptions,
   TStaticMethods extends { [key: string]: unknown }
 > {
-  staticMethods = {} as TStaticMethods;
   private base: CoreExceptionConstructor = BaseException;
   private params?: TParams;
+  private staticMethods = {} as TStaticMethods;
 
   static createCoreException<TName extends ExceptionName>(name: TName): SingleKeyMap<TName, CoreExceptionConstructor> {
     const constructor = class extends BaseException<{ name: TName }, ExceptionOptions> {

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -45,7 +45,16 @@ abstract class BaseException<TParams extends ExceptionParams, TOptions extends E
     this.cause = options?.cause;
     this.details = options?.details;
   }
+
+  // static extend() {
+  //   return class extends this {};
+  // }
 }
+
+abstract class ValueError<TParams extends ExceptionParams, TOptions extends ExceptionOptions> extends BaseException<
+  TParams,
+  TOptions
+> {}
 
 class ExceptionBuilder<TParams extends ExceptionParams | undefined, TOptions extends ExceptionOptions> {
   private params?: TParams;
@@ -74,8 +83,6 @@ class ExceptionBuilder<TParams extends ExceptionParams | undefined, TOptions ext
     return this as unknown as ExceptionBuilder<TUpdatedParams, TOptions>;
   }
 }
-
-const ValueError = new ExceptionBuilder().setParams({ name: 'ValueError' }).build();
 
 export type { ExceptionConstructor, ExceptionInstance };
 export { BaseException, ExceptionBuilder, ValueError };

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -30,6 +30,7 @@ type ExceptionConstructorArgs<TParams extends ExceptionParams, TOptions extends 
 
 type ExceptionConstructor<TParams extends ExceptionParams, TOptions extends ExceptionOptions> = {
   new (...args: ExceptionConstructorArgs<TParams, TOptions>): BaseException<TParams, TOptions>;
+  asErr(...args: ExceptionConstructorArgs<TParams, TOptions>): Err<never, BaseException<TParams, TOptions>>;
   /** inference-only property that will be undefined at runtime */
   infer: BaseException<TParams, TOptions>;
 };
@@ -114,6 +115,11 @@ class ExceptionBuilder<
           options = args[1];
         }
         super(message, options);
+      }
+      static asErr(
+        ...args: ExceptionConstructorArgs<NonNullable<TParams>, TOptions>
+      ): Err<never, BaseException<NonNullable<TParams>, TOptions>> {
+        return new this(...args).toErr();
       }
     };
     return ExceptionBuilder.createResult(constructor, params.name, this.staticMethods);

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -32,7 +32,7 @@ type ExceptionConstructor<TParams extends ExceptionParams, TOptions extends Exce
   new (...args: ExceptionConstructorArgs<TParams, TOptions>): BaseException<TParams, TOptions>;
   asErr(...args: ExceptionConstructorArgs<TParams, TOptions>): Err<never, BaseException<TParams, TOptions>>;
   /** inference-only property that will be undefined at runtime */
-  infer: BaseException<TParams, TOptions>;
+  Instance: BaseException<TParams, TOptions>;
 };
 
 abstract class BaseException<TParams extends ExceptionParams, TOptions extends ExceptionOptions> extends Error {
@@ -103,7 +103,7 @@ class ExceptionBuilder<
     }
     const params = this.params;
     const constructor: ExceptionConstructor<NonNullable<TParams>, TOptions> = class extends this.base {
-      static infer: BaseException<NonNullable<TParams>, TOptions>;
+      static Instance: BaseException<NonNullable<TParams>, TOptions>;
       override name = params.name;
       constructor(...args: ExceptionConstructorArgs<NonNullable<TParams>, TOptions>) {
         let message: string | undefined, options: TOptions | undefined;

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -29,16 +29,20 @@ type ExceptionConstructorArgs<TParams extends ExceptionParams, TOptions extends 
       ? [TOptions]
       : [message: string, options: TOptions];
 
-type ExceptionConstructor<
-  TParams extends ExceptionParams,
-  TOptions extends ExceptionOptions,
-  TStaticProps = unknown
-> = TStaticProps & {
-  new (...args: ExceptionConstructorArgs<TParams, TOptions>): BaseException<TParams, TOptions>;
+type ExceptionStatic<TParams extends ExceptionParams, TOptions extends ExceptionOptions> = {
+  /** return an instance of the exception wrapped in a neverthrow Error object */
   asErr(...args: ExceptionConstructorArgs<TParams, TOptions>): Err<never, BaseException<TParams, TOptions>>;
   /** inference-only property that will be undefined at runtime */
   Instance: BaseException<TParams, TOptions>;
 };
+
+type ExceptionConstructor<
+  TParams extends ExceptionParams,
+  TOptions extends ExceptionOptions,
+  TStaticProps = unknown
+> = ExceptionStatic<TParams, TOptions> &
+  TStaticProps &
+  (new (...args: ExceptionConstructorArgs<TParams, TOptions>) => BaseException<TParams, TOptions>);
 
 abstract class BaseException<TParams extends ExceptionParams, TOptions extends ExceptionOptions> extends Error {
   override cause: TOptions['cause'];

--- a/src/json.ts
+++ b/src/json.ts
@@ -27,7 +27,7 @@ function isSerializedObject<TName extends SerializedObjectName>(
   return Boolean(value.__isSerializedType && value.__deserializedType === name);
 }
 
-export function replacer(this: unknown, key: string, value: unknown) {
+export function replacer(this: unknown, key: string, value: unknown): unknown {
   if (value instanceof Set) {
     return {
       __deserializedType: 'Set',
@@ -44,7 +44,7 @@ export function replacer(this: unknown, key: string, value: unknown) {
   return value;
 }
 
-export function reviver(_: string, value: unknown) {
+export function reviver(_: string, value: unknown): unknown {
   if (isSerializedObject(value, 'Set')) {
     return new Set(value.value);
   } else if (isSerializedObject(value, 'Date')) {

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,5 +1,5 @@
 /** Returns `true` if the value is a string representation of a number */
-export function isStringNumber(value: string) {
+export function isStringNumber(value: string): boolean {
   if (value.trim() !== '') {
     return !Number.isNaN(+value);
   }

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,3 +1,5 @@
+import type { SingleKeyMap } from './types.js';
+
 export type ReadonlyDeep<T extends object> = Readonly<{
   [K in keyof T]: T[K] extends object ? ReadonlyDeep<T[K]> : T[K];
 }>;
@@ -59,4 +61,8 @@ export function filterObject<T extends { [key: string]: unknown }>(
   return Object.fromEntries(
     Object.entries(obj).filter(([key, value]) => callback(value as T[keyof T], key))
   ) as Partial<T>;
+}
+
+export function objectify<K extends PropertyKey, V>(key: K, value: V): SingleKeyMap<K, V> {
+  return { [key]: value } as SingleKeyMap<K, V>;
 }

--- a/src/object.ts
+++ b/src/object.ts
@@ -48,13 +48,15 @@ export function isPlainObject(value: unknown): value is { [key: string]: unknown
   );
 }
 
-export function isAllUndefined<T extends { [key: string]: unknown }>(obj: T) {
+export function isAllUndefined<T extends { [key: string]: unknown }>(obj: T): boolean {
   return Object.values(obj).every((value) => value === undefined);
 }
 
 export function filterObject<T extends { [key: string]: unknown }>(
   obj: T,
   callback: (value: T[keyof T], key: keyof T) => boolean
-) {
-  return Object.fromEntries(Object.entries(obj).filter(([key, value]) => callback(value as T[keyof T], key)));
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key, value]) => callback(value as T[keyof T], key))
+  ) as Partial<T>;
 }

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,23 +1,30 @@
+import { ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
+
+import { ValueException } from './exception.js';
+
 /** Returns a random integer between `min` (inclusive) and `max` (not inclusive) */
-export function randomInt(min: number, max: number): number {
+export function randomInt(min: number, max: number): Result<number, typeof ValueException.Instance> {
   if (min >= max) {
-    throw new Error(`Min value '${min}' must not be greater than or equal to the max value '${max}'`);
+    return ValueException.asErr(`Min value '${min}' must not be greater than or equal to the max value '${max}'`);
   }
-  return Math.floor(Math.random() * (max - min)) + min;
+  return ok(Math.floor(Math.random() * (max - min)) + min);
 }
 
 /** Returns a random date between `start` and `end` (both inclusive) */
-export function randomDate(start: Date, end: Date): Date {
+export function randomDate(start: Date, end: Date): Result<Date, typeof ValueException.Instance> {
   if (start > end) {
-    throw new Error(`Start date '${start.toISOString()}' cannot be greater than end date '${end.toISOString()}'`);
+    return ValueException.asErr(
+      `Start date '${start.toISOString()}' cannot be greater than end date '${end.toISOString()}'`
+    );
   }
-  return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+  return ok(new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime())));
 }
 
 /** Returns a random value from the array */
-export function randomValue<T>(arr: T[]): T {
+export function randomValue<T>(arr: T[]): Result<T, typeof ValueException.Instance> {
   if (arr.length === 0) {
-    throw new Error('Cannot select random value from array of length zero');
+    return ValueException.asErr('Cannot select random value from array of length zero');
   }
-  return arr[randomInt(0, arr.length)]!;
+  return randomInt(0, arr.length).map((index) => arr[index]!);
 }

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,5 +1,5 @@
 /** Returns a random integer between `min` (inclusive) and `max` (not inclusive) */
-export function randomInt(min: number, max: number) {
+export function randomInt(min: number, max: number): number {
   if (min >= max) {
     throw new Error(`Min value '${min}' must not be greater than or equal to the max value '${max}'`);
   }
@@ -7,7 +7,7 @@ export function randomInt(min: number, max: number) {
 }
 
 /** Returns a random date between `start` and `end` (both inclusive) */
-export function randomDate(start: Date, end: Date) {
+export function randomDate(start: Date, end: Date): Date {
   if (start > end) {
     throw new Error(`Start date '${start.toISOString()}' cannot be greater than end date '${end.toISOString()}'`);
   }
@@ -15,9 +15,9 @@ export function randomDate(start: Date, end: Date) {
 }
 
 /** Returns a random value from the array */
-export function randomValue<T>(arr: T[]) {
+export function randomValue<T>(arr: T[]): T {
   if (arr.length === 0) {
     throw new Error('Cannot select random value from array of length zero');
   }
-  return arr[randomInt(0, arr.length)];
+  return arr[randomInt(0, arr.length)]!;
 }

--- a/src/range.ts
+++ b/src/range.ts
@@ -1,20 +1,25 @@
+import { ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
+
+import { ValueException } from './exception.js';
+
 /** Return an array of integers between 0 (inclusive) and `end` (not inclusive) */
-export function range(end: number): readonly number[];
+export function range(end: number): Result<readonly number[], typeof ValueException.Instance>;
 
 /** Return an array of integers between `start` (inclusive) and `end` (not inclusive) */
-export function range(start: number, end: number): readonly number[];
+export function range(start: number, end: number): Result<readonly number[], typeof ValueException.Instance>;
 
-export function range(...args: number[]): readonly number[] {
+export function range(...args: number[]): Result<readonly number[], typeof ValueException.Instance> {
   const start = args.length === 2 ? args[0]! : 0;
   const end = args.length === 2 ? args[1]! : args[0]!;
 
   if (start >= end) {
-    throw new Error(`End of range '${end}' must be greater than start '${start}'`);
+    return ValueException.asErr(`End of range '${end}' must be greater than start '${start}'`);
   }
 
   const values: number[] = [];
   for (let i = start; i < end; i++) {
     values.push(i);
   }
-  return values;
+  return ok(values);
 }

--- a/src/string.ts
+++ b/src/string.ts
@@ -1,32 +1,32 @@
 import type { CamelCase, Primitive, SnakeCase } from 'type-fest';
 
-export function camelToSnakeCase<T extends string>(s: T) {
+export function camelToSnakeCase<T extends string>(s: T): SnakeCase<T> {
   return s.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`) as SnakeCase<T>;
 }
 
-export function snakeToCamelCase<T extends string>(s: T) {
+export function snakeToCamelCase<T extends string>(s: T): CamelCase<T> {
   return s
     .toLowerCase()
     .replace(/([-_][a-z])/g, (group) => group.toUpperCase().replace('-', '').replace('_', '')) as CamelCase<T>;
 }
 
-export function uncapitalize<T extends string>(s: T) {
+export function uncapitalize<T extends string>(s: T): Uncapitalize<T> {
   return (s.charAt(0).toLowerCase() + s.slice(1)) as Uncapitalize<T>;
 }
 
-export function capitalize<T extends string>(s: T) {
+export function capitalize<T extends string>(s: T): Capitalize<T> {
   return (s.charAt(0).toUpperCase() + s.slice(1)) as Capitalize<T>;
 }
 
-export function toLowerCase<T extends string>(s: T) {
+export function toLowerCase<T extends string>(s: T): Lowercase<T> {
   return s.toLowerCase() as Lowercase<T>;
 }
 
-export function toUpperCase<T extends string>(s: T) {
+export function toUpperCase<T extends string>(s: T): Uppercase<T> {
   return s.toUpperCase() as Uppercase<T>;
 }
 
-export function format(s: string, ...args: Exclude<Primitive, symbol>[]) {
+export function format(s: string, ...args: Exclude<Primitive, symbol>[]): string {
   for (const arg of args) {
     s = s.replace('{}', String(arg));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { IfNever } from 'type-fest';
+import type { IfNever, IsStringLiteral } from 'type-fest';
 
 /**
  * Return whether `T` or any record nested therein contains the key `K`
@@ -31,3 +31,16 @@ export type ToAbstractConstructor<T extends new (...args: any[]) => any> = T ext
 ) => infer TReturn
   ? abstract new (...args: TArgs) => TReturn
   : never;
+
+export type IsUnion<T, U = T> = (T extends U ? (U extends T ? true : false) : never) extends true ? false : true;
+
+export type SingleKeyMap<K extends PropertyKey, V> =
+  IsStringLiteral<K> extends true
+    ? IsUnion<K> extends false
+      ? {
+          [key in K]: V;
+        }
+      : never
+    : never;
+
+export type B = SingleKeyMap<'a' | 'b', number>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,3 +25,9 @@ export type HasNestedKey<T, P extends string> = T extends {
   : T extends (infer U)[]
     ? HasNestedKey<U, P>
     : false;
+
+export type ToAbstractConstructor<T extends new (...args: any[]) => any> = T extends new (
+  ...args: infer TArgs extends any[]
+) => infer TReturn
+  ? abstract new (...args: TArgs) => TReturn
+  : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,5 +42,3 @@ export type SingleKeyMap<K extends PropertyKey, V> =
         }
       : never
     : never;
-
-export type B = SingleKeyMap<'a' | 'b', number>;


### PR DESCRIPTION
Functions no longer throw arbitrary errors. Functions that can receive invalid inputs (or can error for any other reason), return `Result`.