### PR TITLE
feat: add vendored neverthrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,16 @@
   "bugs": {
     "url": "https://github.com/DouglasNeuroInformatics/libjs/issues"
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./vendor/*": {
+      "types": "./dist/vendor/*.d.ts",
+      "import": "./dist/vendor/*.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/src/__tests__/exception.test.ts
+++ b/src/__tests__/exception.test.ts
@@ -1,8 +1,8 @@
-import { Err } from 'neverthrow';
 import type { Simplify } from 'type-fest';
 import { describe, expect, expectTypeOf, it, test } from 'vitest';
 
 import { BaseException, ExceptionBuilder, OutOfRangeException, ValueException } from '../exception.js';
+import { Err } from '../vendor/neverthrow.js';
 
 import type { ExceptionConstructor } from '../exception.js';
 

--- a/src/__tests__/http.test.ts
+++ b/src/__tests__/http.test.ts
@@ -1,8 +1,9 @@
-import type { Err } from 'neverthrow';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as datetime from '../datetime.js';
 import { safeFetch, waitForServer } from '../http.js';
+
+import type { Err } from '../vendor/neverthrow.js';
 
 const fetch = vi.hoisted(() => vi.fn());
 const networkError = new Error('Network Error');

--- a/src/__tests__/result.test.ts
+++ b/src/__tests__/result.test.ts
@@ -1,7 +1,7 @@
-import { Err, err, Ok, ok } from 'neverthrow';
 import { describe, expect, it } from 'vitest';
 
 import { asyncResultify } from '../result.js';
+import { Err, err, Ok, ok } from '../vendor/neverthrow.js';
 
 describe('asyncResultify', () => {
   it('should convert a successful Result to ResultAsync', async () => {

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -1,7 +1,7 @@
-import { err, ok } from 'neverthrow';
-import type { Result } from 'neverthrow';
-
 import { OutOfRangeException } from './exception.js';
+import { err, ok } from './vendor/neverthrow.js';
+
+import type { Result } from './vendor/neverthrow.js';
 
 export type Duration = {
   days: number;

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -4,13 +4,13 @@
 
 import cleanStack from 'clean-stack';
 import extractStack from 'extract-stack';
-import { err, errAsync, Result, ResultAsync } from 'neverthrow';
 import stringifyObject from 'stringify-object';
 import type { IsNever, RequiredKeysOf } from 'type-fest';
 import type { z } from 'zod';
 
 import { objectify } from './object.js';
 import { indentLines } from './string.js';
+import { err, errAsync, Result, ResultAsync } from './vendor/neverthrow.js';
 
 import type { SingleKeyMap, ToAbstractConstructor } from './types.js';
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,8 +1,7 @@
-import { ok, ResultAsync } from 'neverthrow';
-
 import { sleep } from './datetime.js';
 import { ExceptionBuilder, RuntimeException } from './exception.js';
 import { asyncResultify } from './result.js';
+import { ok, ResultAsync } from './vendor/neverthrow.js';
 
 import type { ExceptionLike } from './exception.js';
 

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,7 +1,7 @@
-import { ok } from 'neverthrow';
-import type { Result } from 'neverthrow';
-
 import { ValueException } from './exception.js';
+import { ok } from './vendor/neverthrow.js';
+
+import type { Result } from './vendor/neverthrow.js';
 
 /** Returns a random integer between `min` (inclusive) and `max` (not inclusive) */
 export function randomInt(min: number, max: number): Result<number, typeof ValueException.Instance> {

--- a/src/range.ts
+++ b/src/range.ts
@@ -1,7 +1,7 @@
-import { ok } from 'neverthrow';
-import type { Result } from 'neverthrow';
-
 import { ValueException } from './exception.js';
+import { ok } from './vendor/neverthrow.js';
+
+import type { Result } from './vendor/neverthrow.js';
 
 /** Return an array of integers between 0 (inclusive) and `end` (not inclusive) */
 export function range(end: number): Result<readonly number[], typeof ValueException.Instance>;

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,4 @@
-import { Result, ResultAsync } from 'neverthrow';
+import { Result, ResultAsync } from './vendor/neverthrow.js';
 
 export function asyncResultify<T, E>(fn: () => Promise<Result<T, E>>): ResultAsync<T, E> {
   return new ResultAsync(fn());

--- a/src/vendor/neverthrow.ts
+++ b/src/vendor/neverthrow.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/only-throw-error */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+
+import { Err, Ok, Result } from 'neverthrow';
+
+declare module 'neverthrow' {
+  interface Err<T, E> {
+    unwrap(): T;
+  }
+  interface Ok<T, E> {
+    unwrap(): T;
+  }
+}
+
+function unwrap<T, E>(this: Result<T, E>): any {
+  if (this.isErr()) {
+    throw this.error;
+  }
+  return this.value;
+}
+
+Err.prototype.unwrap = unwrap;
+Ok.prototype.unwrap = unwrap;
+
+export { Err, Ok };
+
+export {
+  err,
+  errAsync,
+  fromAsyncThrowable,
+  fromPromise,
+  fromSafePromise,
+  fromThrowable,
+  ok,
+  okAsync,
+  Result,
+  ResultAsync,
+  safeTry
+} from 'neverthrow';

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,10 +1,11 @@
-import { ok } from 'neverthrow';
-import type { Result } from 'neverthrow';
 import { z } from 'zod';
 
 import { ValidationException } from './exception.js';
 import { isNumberLike, parseNumber } from './number.js';
 import { isObject } from './object.js';
+import { ok } from './vendor/neverthrow.js';
+
+import type { Result } from './vendor/neverthrow.js';
 
 /** Used to determine if object is of type `ZodType` independent of specific instances or library versions */
 export function isZodType(arg: unknown): arg is z.ZodTypeAny {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,16 +3,16 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     coverage: {
-      exclude: ['src/index.ts', 'src/types.ts'],
+      exclude: ['src/index.ts', 'src/types.ts', 'src/vendor'],
       include: ['src/**/*'],
       provider: 'v8',
+      skipFull: true,
       thresholds: {
         branches: 100,
         functions: 100,
         lines: 100,
         statements: 100
-      },
-      skipFull: true
+      }
     },
     watch: false
   }


### PR DESCRIPTION
Adds new `unwrap` method. Strikes a balance, so users need to consider whether the code can throw in the context, without forcing boilerplate.

Not planned upstream: https://github.com/supermacro/neverthrow/issues/598