### PR TITLE
fix: issue preventing inference of _output in ZodTypeLike in some cases

### DIFF
--- a/src/zod.ts
+++ b/src/zod.ts
@@ -38,7 +38,7 @@ type ZodTypeLike<TOutput, TInput = unknown> = {
   [key: string]: any;
   readonly _input: TInput;
   readonly _output: TOutput;
-  safeParseAsync: (data: unknown) => Promise<ZodSafeParseResultLike<TOutput>>;
+  safeParseAsync: (data: unknown) => Promise<ZodSafeParseResultLike<NoInfer<TOutput>>>;
   '~standard': {
     [key: string]: any;
     vendor: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal type handling for improved type inference in asynchronous parsing methods. No changes to user-facing features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->